### PR TITLE
Add client-side keyword extraction

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,11 +2,14 @@
 import { useState } from 'react';
 import PdfUploader from '@/components/PdfUploader';
 import SummaryPanel from '@/components/SummaryPanel';
+import KeywordsPanel from '@/components/KeywordsPanel';
 import { summarizeClient } from '@/lib/summarize-client';
+import { extractKeywords } from '@/lib/keywords';
 
 export default function Page() {
   const [srcText, setSrcText] = useState<string>('');
   const [summary, setSummary] = useState<string>('');
+  const [keywords, setKeywords] = useState<string[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
@@ -17,8 +20,10 @@ export default function Page() {
     try {
       const s = await summarizeClient(srcText);
       setSummary(s);
+      setKeywords(extractKeywords(s));
     } catch (e: any) {
       setError(e?.message || 'Özetleme sırasında hata oluştu.');
+      setKeywords([]);
     } finally {
       setLoading(false);
     }
@@ -48,6 +53,7 @@ export default function Page() {
         </button>
         {error && <p className="text-red-600 text-sm">{error}</p>}
         <SummaryPanel summary={summary} />
+        <KeywordsPanel keywords={keywords} />
       </section>
 
       <footer className="pt-8 text-xs text-gray-500">

--- a/src/components/KeywordsPanel.tsx
+++ b/src/components/KeywordsPanel.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+export default function KeywordsPanel({ keywords }: { keywords: string[] }) {
+  if (!keywords.length) return null;
+  return (
+    <div className="space-y-2">
+      <h3 className="font-medium">Kavramlar</h3>
+      <ul className="list-disc pl-6 text-sm">
+        {keywords.map((k) => (
+          <li key={k}>{k}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/keywords.ts
+++ b/src/lib/keywords.ts
@@ -1,0 +1,19 @@
+const STOP_WORDS = new Set([
+  'the','and','for','that','are','with','this','from','have','not','you','your','has','but','was','the','can','all','any','our','out','use','too','its','then','than','they','them','their','there','here','also','very','into','onto','such','may','will','what','when','where','who','why','how','which','while','shall','over','under','again','more','most','some','being','been','were','is','am','about','each','other','could','should','would','might','must','shall','do','does','did','doing','done','ve','bir','ve','bu','da','de','için','ile','veya','ama','en','gibi','çok','daha','ise','kadar','mı','mi','mu','mü','şu','o','onlar','olarak','yani','hem'
+]);
+
+export function extractKeywords(text: string, topN = 5): string[] {
+  const words = text
+    .toLowerCase()
+    .replace(/[^a-zA-ZğüşöçıİĞÜŞÖÇ0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 2 && !STOP_WORDS.has(w));
+
+  const freq: Record<string, number> = {};
+  for (const w of words) freq[w] = (freq[w] || 0) + 1;
+
+  return Object.entries(freq)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, topN)
+    .map(([w]) => w);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,3 +25,5 @@ body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial
 .font-semibold { font-weight: 600; }
 .bg-black { background: #000; }
 .disabled\:opacity-50:disabled { opacity: .5; cursor: not-allowed; }
+.list-disc { list-style-type: disc; }
+.pl-6 { padding-left: 1.5rem; }


### PR DESCRIPTION
## Summary
- derive top keywords from summarized text
- display concepts in new KeywordsPanel component
- support bullet list styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)
- `npm run build` (fails: webpack error parsing onnxruntime bindings)


------
https://chatgpt.com/codex/tasks/task_e_68a59409ddc0832793706eac08e93f79