### PR TITLE
feat: add robust summarization via Hugging Face API

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,17 +19,73 @@ app.get('/', (req, res) => {
   res.render('index', { title: 'AI Study App' });
 });
 
-function simpleSummarize(text) {
-  return text.split(/\s+/).slice(0, 50).join(' ');
+async function simpleSummarize(text) {
+  const apiKey = process.env.HF_API_KEY;
+  const maxChunkSize = 4000; // characters
+  const fallback = (str) => str.split(/\s+/).slice(0, 50).join(' ');
+
+  // Split text into manageable chunks for the API
+  const chunks = [];
+  for (let i = 0; i < text.length; i += maxChunkSize) {
+    chunks.push(text.slice(i, i + maxChunkSize));
+  }
+
+  // If no API key is provided, use the fallback summarizer
+  if (!apiKey) {
+    return chunks.map(fallback).join(' ');
+  }
+
+  const summaries = [];
+  for (const chunk of chunks) {
+    try {
+      const response = await fetch(
+        'https://api-inference.huggingface.co/models/facebook/bart-large-cnn',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({ inputs: chunk, options: { wait_for_model: true } }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`API response status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      if (Array.isArray(data) && data[0] && data[0].summary_text) {
+        summaries.push(data[0].summary_text);
+      } else if (data.error) {
+        throw new Error(data.error);
+      } else {
+        summaries.push(fallback(chunk));
+      }
+    } catch (err) {
+      console.error('Summarization error:', err.message);
+      summaries.push(fallback(chunk));
+    }
+  }
+
+  return summaries.join(' ');
 }
 
-app.post('/api/summarize', (req, res) => {
+app.post('/api/summarize', async (req, res) => {
   const { text } = req.body;
   if (!text) {
     return res.status(400).json({ error: 'Text is required' });
   }
-  const summary = simpleSummarize(text);
-  db.run('INSERT INTO summaries (text, summary) VALUES (?, ?)', [text, summary], function(err) {
+
+  let summary;
+  try {
+    summary = await simpleSummarize(text);
+  } catch (err) {
+    console.error('Summarization failed:', err.message);
+    summary = text.split(/\s+/).slice(0, 50).join(' ');
+  }
+
+  db.run('INSERT INTO summaries (text, summary) VALUES (?, ?)', [text, summary], function (err) {
     if (err) {
       return res.status(500).json({ error: 'Database error' });
     }


### PR DESCRIPTION
## Summary
- Replace placeholder summarization with Hugging Face inference API
- Handle long texts by chunking and falling back to a simple summarizer on error or missing key
- Update summarize endpoint to await async model calls and manage failures gracefully

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5a03eeb288327b04b264b4fa9ecf3