### PR TITLE
feat: load configuration from environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+PORT=3000
+DB_FILE=data.sqlite
+SESSION_SECRET=supersecret

--- a/README.md
+++ b/README.md
@@ -8,11 +8,25 @@ The project now includes a Node.js backend with a SQLite database. Upload a PDF,
    ```bash
    npm install
    ```
-2. Start the development server:
+2. Configure environment variables in `.env`:
+   ```bash
+   PORT=3000
+   DB_FILE=data.sqlite
+   SESSION_SECRET=supersecret
+   ```
+3. Start the development server:
    ```bash
    npm start
    ```
-3. Visit [http://localhost:3000](http://localhost:3000) in your browser.
+4. Visit `http://localhost:${PORT}` in your browser.
+
+## Environment Variables
+
+The following variables are required:
+
+- `PORT` – Port number for the HTTP server.
+- `DB_FILE` – Path to the SQLite database file.
+- `SESSION_SECRET` – Secret used to sign the session ID cookie.
 
 ## Testing
 

--- a/db/index.js
+++ b/db/index.js
@@ -1,6 +1,7 @@
+require('dotenv').config();
 const sqlite3 = require('sqlite3').verbose();
 
-const db = new sqlite3.Database('data.sqlite');
+const db = new sqlite3.Database(process.env.DB_FILE);
 
 db.serialize(() => {
   db.run('CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT)');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
+        "dotenv": "^16.4.5",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
         "express-session": "^1.17.3",
@@ -2719,6 +2720,18 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
-    "dependencies": {
-      "ejs": "^3.1.10",
-      "express": "^5.1.0",
-      "express-session": "^1.17.3",
-      "sqlite3": "^5.1.7",
-      "bcrypt": "^5.1.1"
-    },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "dotenv": "^16.4.5",
+    "ejs": "^3.1.10",
+    "express": "^5.1.0",
+    "express-session": "^1.17.3",
+    "sqlite3": "^5.1.7"
+  },
   "devDependencies": {
     "jest": "^30.0.5",
     "nodemon": "^3.1.10",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const path = require('path');
 const session = require('express-session');
@@ -29,7 +30,7 @@ app.get('/', (req, res) => {
 app.use(authRoutes);
 app.use(summaryRoutes);
 
-const port = process.env.PORT || 3000;
+const port = process.env.PORT;
 if (require.main === module) {
   app.listen(port, () => console.log(`Server listening on port ${port}`));
 }


### PR DESCRIPTION
## Summary
- load configuration from a `.env` file with `dotenv`
- use environment variables for the server port and SQLite database file
- document required environment variables in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a42ca5cc83278094da4aa8664df9