### PR TITLE
Add fallback config values

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const sqlite3 = require('sqlite3').verbose();
 
-const db = new sqlite3.Database(process.env.DB_FILE);
+const db = new sqlite3.Database(process.env.DB_FILE || 'data.sqlite');
 
 db.serialize(() => {
   db.run('CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT)');

--- a/server.js
+++ b/server.js
@@ -30,7 +30,7 @@ app.get('/', (req, res) => {
 app.use(authRoutes);
 app.use(summaryRoutes);
 
-const port = process.env.PORT;
+const port = process.env.PORT || 3000;
 if (require.main === module) {
   app.listen(port, () => console.log(`Server listening on port ${port}`));
 }


### PR DESCRIPTION
## Summary
- Default to port 3000 when `PORT` is not provided
- Use `data.sqlite` when `DB_FILE` is unset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5a8b45ba08327aa7a6d54c527ad25