### PR TITLE
Add landing welcome page with get started route

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -33,3 +33,58 @@ pre {
   list-style: disc;
   margin-left: 1.5rem;
 }
+
+/* Landing page styles */
+body.landing {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: linear-gradient(135deg, #4f46e5, #9333ea);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.landing-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+}
+
+.nav-buttons .nav-btn {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  margin-left: 0.5rem;
+  border-radius: 4px;
+}
+
+.hero {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0 1rem;
+}
+
+.hero .btn {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  margin: 0.5rem;
+  font-size: 1rem;
+}
+
+.hero .primary {
+  background: #fff;
+  color: #4f46e5;
+}
+
+.hero .placeholder {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}

--- a/server.js
+++ b/server.js
@@ -24,6 +24,10 @@ app.use(
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.get('/', (req, res) => {
+  res.render('welcome', { title: 'AI Study App' });
+});
+
+app.get('/summarize', (req, res) => {
   res.render('index', { title: 'AI Study App' });
 });
 

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title><%= title %></title>
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body class="landing">
+  <nav class="landing-nav">
+    <div class="logo">AI Study Helper</div>
+    <div class="nav-buttons">
+      <button class="nav-btn">Docs</button>
+      <button class="nav-btn">Login / Signup</button>
+    </div>
+  </nav>
+  <section class="hero">
+    <h1>Turn study materials into concise summaries</h1>
+    <p>Use AI to effortlessly create study aids from your documents.</p>
+    <div class="hero-buttons">
+      <a href="/summarize" class="btn primary">Get Started</a>
+      <button class="btn placeholder">Explore Tools</button>
+    </div>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Introduce a styled landing page with placeholder buttons and a Get Started link to the summarizer.
- Serve the new landing page at `/` and move the summarizer to `/summarize`.
- Add CSS for the landing page layout and buttons.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5be242ca48327ab2d3f7d1c7e87ca