### PR TITLE
feat: add UI animations and transitions

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -114,6 +114,7 @@ document.getElementById('summarize-btn').addEventListener('click', async () => {
   const wikiLink = document.getElementById('wiki-input').value.trim();
   const summaryEl = document.getElementById('summary');
   summaryEl.textContent = 'Loading...';
+  summaryEl.classList.remove('show');
 
   let text = '';
   let images = [];
@@ -159,6 +160,7 @@ document.getElementById('summarize-btn').addEventListener('click', async () => {
   } catch (err) {
     summaryEl.textContent = 'Error';
   }
+  requestAnimationFrame(() => summaryEl.classList.add('show'));
   loadHistory();
 });
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,6 +1,11 @@
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family: Arial, sans-serif;
   margin: 2rem;
+  animation: fadeIn 0.6s ease-in-out;
 }
 
 h1 {
@@ -13,6 +18,7 @@ h2 {
 
 section {
   margin-bottom: 2rem;
+  animation: fadeUp 0.6s ease-in-out;
 }
 
 input[type="text"] {
@@ -59,6 +65,8 @@ body.landing {
   padding: 0.5rem 1rem;
   margin-left: 0.5rem;
   border-radius: 4px;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .hero {
@@ -77,6 +85,8 @@ body.landing {
   border-radius: 4px;
   margin: 0.5rem;
   font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .hero .primary {
@@ -87,4 +97,29 @@ body.landing {
 .hero .placeholder {
   background: rgba(255, 255, 255, 0.2);
   color: #fff;
+}
+
+.nav-buttons .nav-btn:hover,
+.hero .btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+}
+
+#summary {
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+
+#summary.show {
+  opacity: 1;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
 }

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -37,6 +37,7 @@
         radial-gradient(700px 400px at 60% 80%, rgba(34,211,238,.15), transparent 70%),
         linear-gradient(160deg, var(--bg-3), var(--bg-1) 40%, var(--bg-2));
       background-attachment: fixed;
+      animation: fadeIn .6s ease-in-out;
     }
 
     .bar{
@@ -63,7 +64,8 @@
     .nav-links{display:flex; gap:22px; align-items:center;}
     .nav-links a{color:var(--muted); text-decoration:none; font-weight:600}
     .nav-cta{display:flex; gap:12px; align-items:center}
-    .btn{appearance:none; border:none; cursor:pointer; font-weight:800; border-radius:12px; padding:12px 18px; font-size:.95rem; text-decoration:none; display:inline-block}
+    .btn{appearance:none; border:none; cursor:pointer; font-weight:800; border-radius:12px; padding:12px 18px; font-size:.95rem; text-decoration:none; display:inline-block; transition:transform .2s, box-shadow .2s}
+    .btn:hover{transform:translateY(-2px); box-shadow:0 4px 12px rgba(0,0,0,.3)}
     .btn.primary{
       color:#0b0b14; background:linear-gradient(135deg, var(--btn), var(--accent-cyan));
       box-shadow:0 12px 40px rgba(124,58,237,.35);
@@ -71,7 +73,7 @@
     .btn.secondary{ color:#fff; background:transparent; border:1px solid #3a3253; }
 
     .hero{max-width:var(--maxw); margin:30px auto 80px; padding:0 20px 60px; position:relative}
-    .headline{ text-align:center; }
+    .headline{ text-align:center; animation:fadeUp .8s ease-in-out }
     .headline h1{
       font-size:clamp(28px, 4.6vw, 54px);
       line-height:1.08; margin:8px auto 14px; font-weight:800; letter-spacing:.2px;
@@ -104,6 +106,9 @@
     @media (max-width:980px){
       .nav-links{display:none}
     }
+
+    @keyframes fadeIn{from{opacity:0}to{opacity:1}}
+    @keyframes fadeUp{from{opacity:0; transform:translateY(10px);}to{opacity:1; transform:translateY(0);}}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add global fade-in, smooth scrolling, and section animations
- enhance buttons and summary content with hover transitions and fade-in effects
- animate landing page headline and buttons for a smoother feel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a709914af483279d316a46deeeebaf