### PR TITLE
Add user info and summary deletion endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The project now includes a Node.js backend with a SQLite database. Upload a PDF, the server will generate a basic summary and store it for later viewing. Previously saved summaries can be browsed and clicking a summary shows its full text and generated output.
 
+Users can also fetch their account details via `GET /me` and manage saved summaries with `DELETE /api/summaries/:id`.
+
 ## Setup
 
 1. Install dependencies:

--- a/db/index.js
+++ b/db/index.js
@@ -22,6 +22,10 @@ function findUserByUsername(username, cb) {
   db.get('SELECT id, password FROM users WHERE username = ?', [username], cb);
 }
 
+function getUserById(id, cb) {
+  db.get('SELECT id, username FROM users WHERE id = ?', [id], cb);
+}
+
 function insertSummary(userId, text, summary, cb) {
   db.run('INSERT INTO summaries (user_id, text, summary) VALUES (?, ?, ?)', [userId, text, summary], cb);
 }
@@ -34,10 +38,16 @@ function getSummaryById(id, userId, cb) {
   db.get('SELECT text, summary FROM summaries WHERE id = ? AND user_id = ?', [id, userId], cb);
 }
 
+function deleteSummary(id, userId, cb) {
+  db.run('DELETE FROM summaries WHERE id = ? AND user_id = ?', [id, userId], cb);
+}
+
 module.exports = {
   createUser,
   findUserByUsername,
+  getUserById,
   insertSummary,
   getSummaries,
   getSummaryById,
+  deleteSummary,
 };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const bcrypt = require('bcrypt');
-const { createUser, findUserByUsername } = require('../db');
+const { createUser, findUserByUsername, getUserById } = require('../db');
 
 const router = express.Router();
 
@@ -46,6 +46,18 @@ router.post('/logout', (req, res) => {
       return res.status(500).json({ error: 'Logout failed' });
     }
     res.json({ message: 'Logged out' });
+  });
+});
+
+router.get('/me', (req, res) => {
+  if (!req.session.userId) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  getUserById(req.session.userId, (err, user) => {
+    if (err || !user) {
+      return res.status(500).json({ error: 'User not found' });
+    }
+    res.json({ id: user.id, username: user.username });
   });
 });
 

--- a/routes/summaries.js
+++ b/routes/summaries.js
@@ -1,5 +1,10 @@
 const express = require('express');
-const { insertSummary, getSummaries, getSummaryById } = require('../db');
+const {
+  insertSummary,
+  getSummaries,
+  getSummaryById,
+  deleteSummary,
+} = require('../db');
 
 const router = express.Router();
 
@@ -152,6 +157,16 @@ router.get('/summaries/:id', requireAuth, (req, res) => {
     }
     const summaryHtml = row.summary.replace(/\n/g, '<br>');
     res.render('summary', { title: 'Summary Detail', text: row.text, summary: summaryHtml });
+  });
+});
+
+router.delete('/api/summaries/:id', requireAuth, (req, res) => {
+  const { id } = req.params;
+  deleteSummary(id, req.session.userId, (err) => {
+    if (err) {
+      return res.status(500).json({ error: 'Database error' });
+    }
+    res.json({ message: 'Deleted' });
   });
 });
 


### PR DESCRIPTION
## Summary
- expose `/me` endpoint to retrieve the logged-in user's ID and username
- allow users to remove stored summaries via `DELETE /api/summaries/:id`
- document new capabilities in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0a8e6ab48327b777e185a32acca7